### PR TITLE
imports flat distance circuit, test, and export, and bn254 merklize f…

### DIFF
--- a/location/export_test.go
+++ b/location/export_test.go
@@ -1,9 +1,9 @@
 package location
 
 import (
+	"github.com/consensysMesh/internal/location"
 	"os"
 	"testing"
-	"vintrak/roughdraft/internal/location"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/groth16"

--- a/location/export_test.go
+++ b/location/export_test.go
@@ -1,0 +1,86 @@
+package location
+
+import (
+	"os"
+	"testing"
+	"vintrak/roughdraft/internal/location"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/backend/groth16"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/r1cs"
+	"github.com/consensys/gnark/std/accumulator/merkle"
+)
+
+const (
+	r1csPath     = "../export/location.r1cs"
+	pkPath       = "../export/location.pk"
+	vkPath       = "../export/location.vk"
+	solidityPath = "../export/location.sol"
+)
+
+var correctDistanceWitness = &location.Circuit{
+	Leaf:               "1",
+	Latitude:           32999999999999999 * 69,
+	Longitude:          23999999999999999 * 55,
+	ApprovedLatitude:   32000000000000000 * 69,
+	ApprovedLongitude:  23000000000000000 * 55,
+	MaxAllowedDistance: 89000000000000000,
+	RootHash:           "17323514681925755199865953507809305138106634632225211577149440546648080761228",
+	MerkleProofReceiver: merkle.MerkleProof{
+		RootHash: "17323514681925755199865953507809305138106634632225211577149440546648080761228",
+		Path:     []frontend.Variable{1, 1, 0},
+	},
+}
+
+func TestCircuitSetup(t *testing.T) {
+	r1cs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, correctDistanceWitness)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := os.Create(r1csPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = r1cs.WriteTo(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pk, vk, err := groth16.Setup(r1cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err = os.Create(pkPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = pk.WriteTo(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err = os.Create(vkPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = vk.WriteTo(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err = os.Create(solidityPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = vk.ExportSolidity(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/location/flatdistance.go
+++ b/location/flatdistance.go
@@ -1,0 +1,48 @@
+package location
+
+import (
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/accumulator/merkle"
+	"github.com/consensys/gnark/std/hash/mimc"
+)
+
+type Circuit struct {
+	// ---------------------------------------------------------------------------------------------
+	// SECRET INPUTS
+	Latitude            frontend.Variable
+	Longitude           frontend.Variable
+	MerkleProofReceiver merkle.MerkleProof
+
+	// ---------------------------------------------------------------------------------------------
+	// PUBLIC INPUTS
+
+	Leaf               frontend.Variable `gnark:",public"`
+	ApprovedLatitude   frontend.Variable `gnark:",public"`
+	ApprovedLongitude  frontend.Variable `gnark:",public"`
+	MaxAllowedDistance frontend.Variable `gnark:",public"`
+	RootHash           frontend.Variable `gnark:",public"`
+}
+
+//  Distance Equation with conversion from degrees to meters
+//	(long2 - long1)^2 + (lat2 - lat1)^2 <= (maxDistance)^2
+
+func (circuit *Circuit) Define(api frontend.API) error {
+	hFunc, _ := mimc.NewMiMC(api)
+
+	api.AssertIsEqual(circuit.RootHash, circuit.MerkleProofReceiver.RootHash)
+	circuit.MerkleProofReceiver.VerifyProof(api, &hFunc, circuit.Leaf)
+
+	longDiff := api.Sub(circuit.Longitude, circuit.ApprovedLongitude)
+	latDiff := api.Sub(circuit.Latitude, circuit.ApprovedLatitude)
+
+	longMilesSquared := api.Mul(longDiff, longDiff)
+	latMilesSquared := api.Mul(latDiff, latDiff)
+
+	distanceSquared := api.Add(longMilesSquared, latMilesSquared)
+
+	maxDistanceSquared := api.Mul(circuit.MaxAllowedDistance, circuit.MaxAllowedDistance)
+
+	api.AssertIsLessOrEqual(distanceSquared, maxDistanceSquared)
+
+	return nil
+}

--- a/location/flatdistance_test.go
+++ b/location/flatdistance_test.go
@@ -1,8 +1,8 @@
 package location
 
 import (
+	"github.com/consensysMesh/internal/location"
 	"testing"
-	"vintrak/roughdraft/internal/location"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend"

--- a/location/flatdistance_test.go
+++ b/location/flatdistance_test.go
@@ -1,0 +1,142 @@
+package location
+
+import (
+	"testing"
+	"vintrak/roughdraft/internal/location"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/accumulator/merkle"
+	"github.com/consensys/gnark/test"
+)
+
+const (
+	depth = 3
+)
+
+var incorrectRootHashWitness = &location.Circuit{
+	Leaf:               "1",
+	Latitude:           2000000000000000 * 69,
+	Longitude:          2000000000000000 * 55,
+	ApprovedLatitude:   3000000000000000 * 69,
+	ApprovedLongitude:  3000000000000000 * 55,
+	MaxAllowedDistance: 4 * 1000000000000000,
+	RootHash:           "5",
+	MerkleProofReceiver: merkle.MerkleProof{
+		RootHash: "5",
+		Path:     []frontend.Variable{1, 1, 0},
+	},
+}
+
+var incorrectDistanceWitnessOneDegreeLatLong = &location.Circuit{
+	Leaf:               "1",
+	Latitude:           32999999999999999 * 69,
+	Longitude:          23999999999999999 * 55,
+	ApprovedLatitude:   32000000000000000 * 69,
+	ApprovedLongitude:  23000000000000000 * 55,
+	MaxAllowedDistance: 88000000000000000,
+	RootHash:           "17323514681925755199865953507809305138106634632225211577149440546648080761228",
+	MerkleProofReceiver: merkle.MerkleProof{
+		RootHash: "17323514681925755199865953507809305138106634632225211577149440546648080761228",
+		Path:     []frontend.Variable{1, 1, 0},
+	},
+}
+
+var incorrectDistanceWitnessOneDegreeLat = &location.Circuit{
+	Leaf:               "1",
+	Latitude:           32999999999999999 * 69,
+	Longitude:          23000000000000000 * 55,
+	ApprovedLatitude:   32000000000000000 * 69,
+	ApprovedLongitude:  23000000000000000 * 55,
+	MaxAllowedDistance: 68000000000000000,
+	RootHash:           "17323514681925755199865953507809305138106634632225211577149440546648080761228",
+	MerkleProofReceiver: merkle.MerkleProof{
+		RootHash: "17323514681925755199865953507809305138106634632225211577149440546648080761228",
+		Path:     []frontend.Variable{1, 1, 0},
+	},
+}
+
+var incorrectDistanceWitnessOneDegreeLong = &location.Circuit{
+	Leaf:               "1",
+	Latitude:           32000000000000000 * 69,
+	Longitude:          23999999999999999 * 55,
+	ApprovedLatitude:   32000000000000000 * 69,
+	ApprovedLongitude:  23000000000000000 * 55,
+	MaxAllowedDistance: 54000000000000000,
+	RootHash:           "17323514681925755199865953507809305138106634632225211577149440546648080761228",
+	MerkleProofReceiver: merkle.MerkleProof{
+		RootHash: "17323514681925755199865953507809305138106634632225211577149440546648080761228",
+		Path:     []frontend.Variable{1, 1, 0},
+	},
+}
+
+var correctDistanceWitnessOneDegreeLatLong = &location.Circuit{
+	Leaf:               "1",
+	Latitude:           32999999999999999 * 69,
+	Longitude:          23999999999999999 * 55,
+	ApprovedLatitude:   32000000000000000 * 69,
+	ApprovedLongitude:  23000000000000000 * 55,
+	MaxAllowedDistance: 89000000000000000,
+	RootHash:           "17323514681925755199865953507809305138106634632225211577149440546648080761228",
+	MerkleProofReceiver: merkle.MerkleProof{
+		RootHash: "17323514681925755199865953507809305138106634632225211577149440546648080761228",
+		Path:     []frontend.Variable{1, 1, 0},
+	},
+}
+
+var correctDistanceWitnessOneDegreeLat = &location.Circuit{
+	Leaf:               "1",
+	Latitude:           32999999999999999 * 69,
+	Longitude:          23000000000000000 * 55,
+	ApprovedLatitude:   32000000000000000 * 69,
+	ApprovedLongitude:  23000000000000000 * 55,
+	MaxAllowedDistance: 69000000000000000,
+	RootHash:           "17323514681925755199865953507809305138106634632225211577149440546648080761228",
+	MerkleProofReceiver: merkle.MerkleProof{
+		RootHash: "17323514681925755199865953507809305138106634632225211577149440546648080761228",
+		Path:     []frontend.Variable{1, 1, 0},
+	},
+}
+
+var correctDistanceWitnessOneDegreeLong = &location.Circuit{
+	Leaf:               "1",
+	Latitude:           32000000000000000 * 69,
+	Longitude:          23999999999999999 * 55,
+	ApprovedLatitude:   32000000000000000 * 69,
+	ApprovedLongitude:  23000000000000000 * 55,
+	MaxAllowedDistance: 55000000000000000,
+	RootHash:           "17323514681925755199865953507809305138106634632225211577149440546648080761228",
+	MerkleProofReceiver: merkle.MerkleProof{
+		RootHash: "17323514681925755199865953507809305138106634632225211577149440546648080761228",
+		Path:     []frontend.Variable{1, 1, 0},
+	},
+}
+
+var correctDistanceWitnessNegativeDegrees = &location.Circuit{
+	Leaf:               "1",
+	Latitude:           -32999999999999999 * 69,
+	Longitude:          -23999999999999999 * 55,
+	ApprovedLatitude:   -32000000000000000 * 69,
+	ApprovedLongitude:  -23000000000000000 * 55,
+	MaxAllowedDistance: 89000000000000000,
+	RootHash:           "17323514681925755199865953507809305138106634632225211577149440546648080761228",
+	MerkleProofReceiver: merkle.MerkleProof{
+		RootHash: "17323514681925755199865953507809305138106634632225211577149440546648080761228",
+		Path:     []frontend.Variable{1, 1, 0},
+	},
+}
+
+func TestLocationCircuit(t *testing.T) {
+	assert := test.NewAssert(t)
+	var locationCircuit location.Circuit
+	locationCircuit.MerkleProofReceiver.Path = make([]frontend.Variable, depth)
+	assert.ProverFailed(&locationCircuit, incorrectRootHashWitness, test.WithCurves(ecc.BN254), test.WithBackends(backend.GROTH16), test.WithCompileOpts(frontend.IgnoreUnconstrainedInputs()))
+	assert.ProverFailed(&locationCircuit, incorrectDistanceWitnessOneDegreeLatLong, test.WithCurves(ecc.BN254), test.WithBackends(backend.GROTH16), test.WithCompileOpts(frontend.IgnoreUnconstrainedInputs()))
+	assert.ProverFailed(&locationCircuit, incorrectDistanceWitnessOneDegreeLat, test.WithCurves(ecc.BN254), test.WithBackends(backend.GROTH16), test.WithCompileOpts(frontend.IgnoreUnconstrainedInputs()))
+	assert.ProverFailed(&locationCircuit, incorrectDistanceWitnessOneDegreeLong, test.WithCurves(ecc.BN254), test.WithBackends(backend.GROTH16), test.WithCompileOpts(frontend.IgnoreUnconstrainedInputs()))
+	assert.ProverSucceeded(&locationCircuit, correctDistanceWitnessOneDegreeLatLong, test.WithCurves(ecc.BN254), test.WithBackends(backend.GROTH16), test.WithCompileOpts(frontend.IgnoreUnconstrainedInputs()))
+	assert.ProverSucceeded(&locationCircuit, correctDistanceWitnessOneDegreeLat, test.WithCurves(ecc.BN254), test.WithBackends(backend.GROTH16), test.WithCompileOpts(frontend.IgnoreUnconstrainedInputs()))
+	assert.ProverSucceeded(&locationCircuit, correctDistanceWitnessOneDegreeLong, test.WithCurves(ecc.BN254), test.WithBackends(backend.GROTH16), test.WithCompileOpts(frontend.IgnoreUnconstrainedInputs()))
+	assert.ProverSucceeded(&locationCircuit, correctDistanceWitnessNegativeDegrees, test.WithCurves(ecc.BN254), test.WithBackends(backend.GROTH16), test.WithCompileOpts(frontend.IgnoreUnconstrainedInputs()))
+}

--- a/merkle/merklize.go
+++ b/merkle/merklize.go
@@ -1,0 +1,114 @@
+package merkle
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"math/big"
+	"math/rand"
+	"os"
+	"strconv"
+
+	"github.com/consensys/gnark-crypto/accumulator/merkletree"
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/hash"
+)
+
+func Merklize(s []string, depth int, leafIndex uint64) (string, string, []string, error) {
+
+	type testData struct {
+		hash        hash.Hash
+		segmentSize int
+		curve       ecc.ID
+	}
+
+	type proofSet struct {
+		proofIndex string
+		RootHash   string
+		Path       []string
+	}
+
+	n := 1
+	for len(s)-int(math.Pow(2, float64(n))) > 0 {
+		n += 1
+	}
+
+	diff := int(math.Pow(2, float64(n))) - len(s)
+	for diff > 0 {
+		s = append(s, "0")
+		diff--
+	}
+
+	confs := []testData{
+		{hash.MIMC_BN254, len(s), ecc.BN254},
+	}
+
+	var proof proofSet
+
+	rand.Seed(1)
+	for _, tData := range confs {
+
+		// for proofIndex := uint64(0); proofIndex < uint64(len(s)); proofIndex++
+
+		var buf bytes.Buffer
+		var hexValue string
+		addedInt := 0
+		for i := 0; i < len(s); i++ {
+			for j := 0; j < tData.segmentSize; j++ {
+				leaf := hex.EncodeToString([]byte(s[j]))
+				for len(leaf) > 0 {
+					if len(leaf) >= 12 {
+						hexValue = leaf[0:12]
+						leaf = leaf[12:]
+
+					} else {
+						hexValue = leaf[0:]
+						leaf = ""
+					}
+					intValue, err := strconv.ParseUint(hexValue, 16, 64)
+					if err != nil {
+						fmt.Println(err)
+						return "", "", nil, err
+					}
+					addedInt += int(intValue)
+
+				}
+				addedInt += rand.Int()
+				stringInt := strconv.Itoa(addedInt)
+				slicedStringInt := stringInt[len(stringInt)-3:]
+				finalInt, err := strconv.Atoi(slicedStringInt)
+				if err != nil {
+					return "", "", nil, err
+				}
+				r := byte(finalInt)
+				buf.Write([]byte{r})
+			}
+		}
+
+		// create the proof using the go code
+		hGo := tData.hash.New()
+		merkleRoot, proofPath, numLeaves, err := merkletree.BuildReaderProof(&buf, hGo, tData.segmentSize, leafIndex)
+		if err != nil {
+			return "", "", nil, err
+		}
+
+		// verfiy the proof in plain go
+		verified := merkletree.VerifyProof(hGo, merkleRoot, proofPath, leafIndex, numLeaves)
+		if !verified {
+			fmt.Println("The merkle proof in plain go should pass")
+			os.Exit(-1)
+		}
+
+		bigInt := new(big.Int)
+		for i := 0; i < len(proofPath); i++ {
+			nCopy := new(big.Int).Set(bigInt.SetBytes(proofPath[i]))
+			if nCopy != nil {
+				proof.Path = append(proof.Path, nCopy.String())
+			}
+		}
+		proof.proofIndex = strconv.Itoa(int(leafIndex))
+		proof.RootHash = bigInt.SetBytes(merkleRoot).String()
+	}
+	return proof.proofIndex, proof.RootHash, proof.Path, nil
+}


### PR DESCRIPTION
Imports the flat distance circuit confirming a long-lat coord is less than or equal to a max distance away from a second long-lat cord. Imports circuits accompanying tests and export test file for solidity use. Imports the merklize function capable of constructing an n layered Merkle tree based on the bn254 curve. 